### PR TITLE
change ops interval to good's default 15s

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ exports.init = async () => {
   // logging
   if (!env.TESTING) {
     const options = {
-      ops: env.PROD ? { interval: 1000 } : false,
+      ops: env.PROD ? { interval: 15000 } : false,
       includes: {
         response: ['payload', 'headers'],
         request: ['payload', 'headers'],


### PR DESCRIPTION
The 1s interval caused a 15G log file on the hosted dev api :scream: